### PR TITLE
fix: clear persisted cache to show fresh gallery data after upload

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -123,9 +123,11 @@ export default function UploadPage() {
           });
         }
         
-        // Set flag for gallery to force refetch (reliable for mobile)
+        // Clear persisted cache and set flag for gallery to force refetch
         try {
+          localStorage.removeItem('WEDDING_GALLERY_CACHE'); // Clear persisted React Query cache
           localStorage.setItem('forceGalleryRefetch', 'true');
+          logger.info('Cleared persisted cache before navigation');
         } catch (e) {
           // Ignore localStorage errors
         }

--- a/src/components/gallery/GalleryWithReactQuery.tsx
+++ b/src/components/gallery/GalleryWithReactQuery.tsx
@@ -42,12 +42,13 @@ export default function GalleryWithReactQuery() {
       const shouldRefetch = localStorage.getItem('forceGalleryRefetch');
       if (shouldRefetch === 'true') {
         localStorage.removeItem('forceGalleryRefetch');
-        // React Query will automatically refetch due to staleTime: 0
+        logger.info('Force refetching gallery data after upload');
+        refetch(); // Explicitly refetch instead of relying on automatic refetch
       }
     } catch (e) {
       // Ignore localStorage errors
     }
-  }, []);
+  }, [refetch]);
 
   const { all: totalCount, photos: photoCount, videos: videoCount } = useAllMediaCounts();
 


### PR DESCRIPTION
- Clear WEDDING_GALLERY_CACHE from localStorage before navigating to gallery
- Add explicit refetch() call when forceGalleryRefetch flag is set
- Ensures newly uploaded media appears immediately in gallery
- Prevents stale persisted cache from being loaded before refetch